### PR TITLE
fix: Adjust input arg for binary.Read

### DIFF
--- a/proxy/marshaler.go
+++ b/proxy/marshaler.go
@@ -238,7 +238,7 @@ func readBytes(dataBytes []byte, elementType tensorType, index int, numElements 
 	start := index * tensorSize
 	buf := bytes.NewBuffer(dataBytes[start : start+tensorSize])
 	data := reflect.MakeSlice(elementType.sliceType, numElements, numElements).Interface()
-	return &data, binary.Read(buf, binary.LittleEndian, &data)
+	return data, binary.Read(buf, binary.LittleEndian, data)
 }
 
 func sliceType(v interface{}) reflect.Type {


### PR DESCRIPTION
This call was throwing an error: `invalid type *interface {}"`. This is encountered when processing inference responses from the Triton runtime (which uses the `RawOutputContents` field).

This input was adjusted to align with the expected type and a simple test was added that covers this area of code.
