### PR TITLE
chore: Use non-root user in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -90,5 +90,7 @@ FROM scratch AS runtime
 
 ARG USER=2000
 
+USER ${USER}
+
 COPY --from=build /go/bin/server /go/bin/server
 CMD ["/go/bin/server"]


### PR DESCRIPTION
We have an arg  for the user, but we weren't using it. This fix sets the user in the runtime target image.