### PR TITLE
Push multi-arch docker image

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
     tags:
       - v*
+  pull_request:
 
 jobs:
   test:
@@ -22,22 +23,49 @@ jobs:
   build:
     needs: test
     runs-on: ubuntu-latest
+    if: github.event_name == 'push'
+
     env:
-      IMAGE_NAME: kserve/rest-proxy
+      IMAGE_NAME: rest-proxy
+
     steps:
       - uses: actions/checkout@v2
-      - name: Build runtime image
-        run: make build
-      - name: Log in to Docker Hub
-        run: docker login -u ${{ secrets.DOCKER_USER }} -p ${{ secrets.DOCKER_ACCESS_TOKEN }}
-      - name: Push to Docker Hub
+
+      - name: Setup QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_USER }}
+          password: ${{ secrets.DOCKER_ACCESS_TOKEN }}
+
+      - name: export version variables
         run: |
+          IMAGE_ID=kserve/$IMAGE_NAME
+
+          # Change all uppercase to lowercase
+          IMAGE_ID=$(echo $IMAGE_ID | tr '[A-Z]' '[a-z]')
+
           # Strip git ref prefix from version
           VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
-          echo $VERSION
+
+          # Strip "v" prefix from tag name
+          # [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
 
           # Use Docker `latest` tag convention
           [ "$VERSION" == "main" ] && VERSION=latest
 
-          docker tag ${{ env.IMAGE_NAME }}:latest ${{ env.IMAGE_NAME }}:$VERSION
-          docker push ${{ env.IMAGE_NAME }}:$VERSION
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
+          echo "IMAGE_ID=$IMAGE_ID" >> $GITHUB_ENV
+
+      - name: Build and push
+        uses: docker/build-push-action@v3
+        with:
+          platforms: linux/amd64,linux/arm/v7,linux/arm64/v8,linux/ppc64le,linux/s390x
+          push: true
+          tags: ${{ env.IMAGE_ID }}:${{ env.VERSION }}
+          target: runtime


### PR DESCRIPTION
cherry-picked from https://github.com/kserve/modelmesh/pull/76

in order to run the kserve helm chart on an arm64 cluster