### PR TITLE
chore: Build not push on Pull Request

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
     tags:
       - v*
+  pull_request:
 
 jobs:
   test:
@@ -29,8 +30,10 @@ jobs:
       - name: Build runtime image
         run: make build
       - name: Log in to Docker Hub
+        if: github.event_name == 'push'
         run: docker login -u ${{ secrets.DOCKER_USER }} -p ${{ secrets.DOCKER_ACCESS_TOKEN }}
       - name: Push to Docker Hub
+        if: github.event_name == 'push'
         run: |
           # Strip git ref prefix from version
           VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')


### PR DESCRIPTION
For Pull Requests we should run the `docker build` but not `docker push` to verify that code changes, changes to the Dockerfile, or changed dependencies do not break the Docker build.

/cc @njhill 
/assign @njhill 