### PR TITLE
Add Makefile documentation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,27 +27,27 @@ endif
 all: build
 
 .PHONY: build
-## Build runtime docker image
+## Build runtime Docker image
 build:
 	docker build -t ${IMG_NAME}:latest --target runtime .
 
 .PHONY: build.develop
-## Build develop docker image
+## Build develop container image
 build.develop:
 	docker build -t ${IMG_NAME}-develop:latest --target develop .
 
 .PHONY: develop
-## Build develop docker image and run an interactive shell in the develop envionment
+## Run interactive shell inside developer container
 develop: build.develop
 	./scripts/develop.sh
 
 .PHONY: run
-## Build develop docker image and run a make command in the develop envionment (e.g. `make run fmt` will execute `make fmt` within the docker container)
+## Run make target inside developer container (e.g. `make run fmt`)
 run: build.develop
 	./scripts/develop.sh make $(RUN_ARGS)
 
 .PHONY: fmt
-## Run formatting
+## Auto-format source code and report code-style violations (lint)
 fmt:
 	./scripts/fmt.sh
 
@@ -56,11 +56,11 @@ fmt:
 test:
 	go test -coverprofile cover.out `go list ./...`
 
+.DEFAULT_GOAL := help
 .PHONY: help
 ## Print Makefile documentation
 help:
-	@perl -0 -nle 'printf("%-25s - %s\n", "$$2", "$$1") while m/^##\s*([^\r\n]+)\n^([\w-]+):[^=]/gm' $(MAKEFILE_LIST) | sort
-.DEFAULT_GOAL := help
+	@perl -0 -nle 'printf("\033[36m  %-15s\033[0m %s\n", "$$2", "$$1") while m/^##\s*([^\r\n]+)\n^([\w.-]+):[^=]/gm' $(MAKEFILE_LIST) | sort
 
 # Override targets if they are included in RUN_ARGs so it doesn't run them twice
 # otherwise 'make run fmt' would be equivalent to calling './scripts/develop.sh make fmt'

--- a/Makefile
+++ b/Makefile
@@ -23,31 +23,44 @@ ifeq (run,$(firstword $(MAKECMDGOALS)))
 endif
 
 .PHONY: all
+## Alias for `build`
 all: build
 
 .PHONY: build
+## Build runtime docker image
 build:
 	docker build -t ${IMG_NAME}:latest --target runtime .
 
 .PHONY: build.develop
+## Build develop docker image
 build.develop:
 	docker build -t ${IMG_NAME}-develop:latest --target develop .
 
 .PHONY: develop
+## Build develop docker image and run an interactive shell in the develop envionment
 develop: build.develop
 	./scripts/develop.sh
 
 .PHONY: run
+## Build develop docker image and run a make command in the develop envionment (e.g. `make run fmt` will execute `make fmt` within the docker container)
 run: build.develop
 	./scripts/develop.sh make $(RUN_ARGS)
 
 .PHONY: fmt
+## Run formatting
 fmt:
 	./scripts/fmt.sh
 
 .PHONY: test
+## Run tests
 test:
 	go test -coverprofile cover.out `go list ./...`
+
+.PHONY: help
+## Print Makefile documentation
+help:
+	@perl -0 -nle 'printf("%-25s - %s\n", "$$2", "$$1") while m/^##\s*([^\r\n]+)\n^([\w-]+):[^=]/gm' $(MAKEFILE_LIST) | sort
+.DEFAULT_GOAL := help
 
 # Override targets if they are included in RUN_ARGs so it doesn't run them twice
 # otherwise 'make run fmt' would be equivalent to calling './scripts/develop.sh make fmt'


### PR DESCRIPTION
#### Motivation

https://github.com/kserve/modelmesh-runtime-adapter/pull/38#discussion_r1193083493

#### Modifications

Add help texts

#### Result

```
all                       - Alias for `build`
build                     - Build runtime docker image
develop                   - Build develop docker image and run an interactive shell in the develop envionment
fmt                       - Run formatting
help                      - Print Makefile documentation
run                       - Build develop docker image and run a make command in the develop envionment (e.g. `make run fmt` will execute `make fmt` within the docker container)
test                      - Run tests
```
