### PR TITLE
chore: Add code generation to Makefile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -76,13 +76,15 @@ WORKDIR /opt/app
 
 COPY go.mod go.sum ./
 
-# Install go protoc plugins
+# Install go protoc plugins,
+# no required module provides package google.golang.org/grpc/cmd/protoc-gen-go-grpc
+# to add it run `go get google.golang.org/grpc/cmd/protoc-gen-go-grpc`
 ENV PATH $HOME/go/bin:$PATH
 RUN true \
-    && go get google.golang.org/protobuf/cmd/protoc-gen-go \
-              google.golang.org/grpc/cmd/protoc-gen-go-grpc \
-    && go install google.golang.org/protobuf/cmd/protoc-gen-go \
-                  google.golang.org/grpc/cmd/protoc-gen-go-grpc \
+    && go get google.golang.org/grpc/cmd/protoc-gen-go-grpc \
+    && go install google.golang.org/grpc/cmd/protoc-gen-go-grpc \
+                  google.golang.org/protobuf/cmd/protoc-gen-go \
+                  github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-grpc-gateway \
     && protoc-gen-go --version \
     && true
 

--- a/Makefile
+++ b/Makefile
@@ -31,11 +31,7 @@ all: generate build test
 generate: google/api/annotations.proto google/api/http.proto
 	protoc -I . --grpc-gateway_out ./gen/ --grpc-gateway_opt logtostderr=true --grpc-gateway_opt paths=source_relative grpc_predict_v2.proto
 
-google/api/annotations.proto:
-	@mkdir -p google/api
-	@test -f $@ || wget --inet4-only -q -O $@ https://raw.githubusercontent.com/googleapis/googleapis/master/$@
-
-google/api/http.proto:
+google/api/%.proto:
 	@mkdir -p google/api
 	@test -f $@ || wget --inet4-only -q -O $@ https://raw.githubusercontent.com/googleapis/googleapis/master/$@
 

--- a/Makefile
+++ b/Makefile
@@ -23,8 +23,21 @@ ifeq (run,$(firstword $(MAKECMDGOALS)))
 endif
 
 .PHONY: all
-## Alias for `build`
-all: build
+## Alias for `generate build test`
+all: generate build test
+
+.PHONY: generate
+## Generate GRPC gateway stubs
+generate: google/api/annotations.proto google/api/http.proto
+	protoc -I . --grpc-gateway_out ./gen/ --grpc-gateway_opt logtostderr=true --grpc-gateway_opt paths=source_relative grpc_predict_v2.proto
+
+google/api/annotations.proto:
+	@mkdir -p google/api
+	@test -f $@ || wget --inet4-only -q -O $@ https://raw.githubusercontent.com/googleapis/googleapis/master/$@
+
+google/api/http.proto:
+	@mkdir -p google/api
+	@test -f $@ || wget --inet4-only -q -O $@ https://raw.githubusercontent.com/googleapis/googleapis/master/$@
 
 .PHONY: build
 ## Build runtime Docker image

--- a/README.md
+++ b/README.md
@@ -2,18 +2,50 @@
 
 # KServe V2 REST Proxy
 
-This REST Proxy leverages [gRPC-Gateway](https://github.com/grpc-ecosystem/grpc-gateway) to create a reverse-proxy server which translates a RESTful HTTP API into gRPC. This allows sending inference requests using the [KServe V2 REST Predict Protocol](https://github.com/kserve/kserve/blob/master/docs/predict-api/v2/required_api.md#httprest) to platforms that expect the [gRPC V2 Predict Protocol](https://github.com/kserve/kserve/blob/master/docs/predict-api/v2/required_api.md#grpc).
+This REST Proxy leverages [gRPC-Gateway](https://github.com/grpc-ecosystem/grpc-gateway)
+to create a reverse-proxy server which translates a RESTful HTTP API into gRPC.
+This allows sending inference requests using the [KServe V2 REST Predict Protocol](https://github.com/kserve/kserve/blob/master/docs/predict-api/v2/required_api.md#httprest)
+to platforms that expect the [gRPC V2 Predict Protocol](https://github.com/kserve/kserve/blob/master/docs/predict-api/v2/required_api.md#grpc).
 
 **Note:** This is currently a work in progress, and is subject to performance and usability issues.
 
-### Generate grpc-gateway stubs
+### Install the ProtoBuf compiler
+
+The protocol buffer compiler, `protoc` is required to compile the `.proto` files.
+To install it, follow the instructions [here](https://grpc.io/docs/protoc-installation/).
+
+### Generate the gRPC gateway stubs
+
+After changing the `grpc_predict_v2.proto` file, run the `protoc` compiler to regenerate
+the gRPC gateway code stubs. It's recommended to use the developer image which has
+all the required libraries pre-installed.
 
 ```bash
-protoc -I . --grpc-gateway_out ./gen/ --grpc-gateway_opt logtostderr=true --grpc-gateway_opt paths=source_relative grpc_predict_v2.proto
+make run generate
 ```
 
-### Build Docker image
+### Build the Docker image
+
+After regenerating the gRPC gateway stubs, rebuild the `rest-proxy` Docker image.
 
 ```bash
-docker build -t kserve/rest-proxy:latest .
+make build
 ```
+
+### Push the Docker image
+
+Before pushing the new `rest-proxy` image to your container registry, re-tag the
+image created by `make build` in the step above.
+
+```bash
+DOCKER_USER="kserve"
+DOCKER_TAG="dev"
+docker tag kserve/rest-proxy:latest ${DOCKER_USER}/rest-proxy:${DOCKER_TAG}
+docker push ${DOCKER_USER}/rest-proxy:${DOCKER_TAG}
+```
+
+### Update your ModelMesh deployment
+
+In order to use the newly built `rest-proxy` image in a [Modelmesh Serving deployment](https://github.com/kserve/modelmesh-serving#modelmesh-serving) update the `restProxy.image` in [config/default/config-defaults.yaml](https://github.com/kserve/modelmesh-serving/blob/v0.11.0/config/default/config-defaults.yaml#L31-L32) and (re)deploy the Modelmesh Serving.
+
+To update a running deployment of ModelMesh serving, add or update the `restProxy.image` section in the `model-serving-config` `ConfigMap` as described the [Modelmesh Serving configuration instructions](https://github.com/kserve/modelmesh-serving/tree/main/docs/configuration).

--- a/README.md
+++ b/README.md
@@ -46,6 +46,6 @@ docker push ${DOCKER_USER}/rest-proxy:${DOCKER_TAG}
 
 ### Update your ModelMesh deployment
 
-In order to use the newly built `rest-proxy` image in a [Modelmesh Serving deployment](https://github.com/kserve/modelmesh-serving#modelmesh-serving) update the `restProxy.image` in [config/default/config-defaults.yaml](https://github.com/kserve/modelmesh-serving/blob/v0.11.0/config/default/config-defaults.yaml#L31-L32) and (re)deploy the Modelmesh Serving.
+In order to use the newly built `rest-proxy` image in a [ModelMesh Serving deployment](https://github.com/kserve/modelmesh-serving#modelmesh-serving) update the `restProxy.image` in [config/default/config-defaults.yaml](https://github.com/kserve/modelmesh-serving/blob/v0.11.0/config/default/config-defaults.yaml#L31-L32) and (re)deploy the ModelMesh Serving.
 
-To update a running deployment of ModelMesh serving, add or update the `restProxy.image` section in the `model-serving-config` `ConfigMap` as described the [Modelmesh Serving configuration instructions](https://github.com/kserve/modelmesh-serving/tree/main/docs/configuration).
+To update a running deployment of ModelMesh serving, add or update the `restProxy.image` section in the `model-serving-config` `ConfigMap` as described the [ModelMesh Serving configuration instructions](https://github.com/kserve/modelmesh-serving/tree/main/docs/configuration).

--- a/scripts/develop.sh
+++ b/scripts/develop.sh
@@ -39,14 +39,14 @@ exit 1
 esac
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-cd "${DIR}/.." ||
+cd "${DIR}/.."
 
 # Make sure .bash_history exists and is a file
-touch .bash_history
+touch ".bash_history"
 
 declare -a docker_run_args=(
   -v "${PWD}:/opt/app"
-  -v "${PWD}/.bash_history:/opt/app/.bash_history"
+  -v "${PWD}/.bash_history:/root/.bash_history"
 )
 
 if [ "${CI}" != "true" ]; then
@@ -55,7 +55,7 @@ if [ "${CI}" != "true" ]; then
   )
 else
   docker_run_args+=(
-    -e CI=true
+    "-e CI=true"
   )
 fi
 


### PR DESCRIPTION
* Pre-install grpc-gateway plugin in developer Docker image
* Add `generate` make target to run protoc and automatically download required .proto files
* Add developer instructions to README.md