### PR TITLE
chore: Upgrade Golang version from 1.18 to 1.19

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+.env
+.dockerignore
+.vscode
+.DS_Store
+Dockerfile
+temp
+.pre-commit.log
+

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ google/
 
 # IDE
 .idea/
+
+.pre-commit.log

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ google/
 .idea/
 
 .pre-commit.log
+

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -93,16 +93,13 @@ linters:
   fast: false
   enable:
     # These are the defaults for golangci-lint
-    - deadcode
     - errcheck
     - gosimple
     - govet
     - ineffassign
     - staticcheck
-    - structcheck
     - typecheck
     - unused
-    - varcheck
 
     # Also enable these
     - goconst

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 repos:
   - repo: https://github.com/golangci/golangci-lint
-    rev: v1.50.1
+    rev: v1.51.1
     hooks:
       - id: golangci-lint
         entry: golangci-lint run

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,6 +16,7 @@ repos:
     rev: v1.51.1
     hooks:
       - id: golangci-lint
+        log_file: .pre-commit.log
         entry: golangci-lint run
         exclude: ^(gen/)
         args:
@@ -24,6 +25,7 @@ repos:
     rev: v2.4.1
     hooks:
       - id: prettier
+        log_file: .pre-commit.log
         exclude: ^(.github/)
         args:
           - --no-bracket-spacing

--- a/Dockerfile
+++ b/Dockerfile
@@ -94,6 +94,7 @@ RUN true \
 COPY .pre-commit-config.yaml ./
 RUN git init && \
     pre-commit install-hooks && \
+    git config --global --add safe.directory "*" && \
     rm -rf .git
 
 # Download dependencies before copying the source so they will be cached
@@ -127,7 +128,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
     GOARCH=${TARGETARCH:-amd64} \
     CGO_ENABLED=0 \
     GO111MODULE=on \
-    go mod tidy && go build -a -o /go/bin/server ./proxy/
+    go build -a -o /go/bin/server ./proxy/
 
 
 ###############################################################################

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@
 ###############################################################################
 # Stage 1: Create the developer image for the BUILDPLATFORM only
 ###############################################################################
-ARG GOLANG_VERSION=1.18
+ARG GOLANG_VERSION=1.19
 FROM --platform=$BUILDPLATFORM registry.access.redhat.com/ubi8/go-toolset:$GOLANG_VERSION AS develop
 
 ARG PROTOC_VERSION=21.12
@@ -127,13 +127,13 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
     GOARCH=${TARGETARCH:-amd64} \
     CGO_ENABLED=0 \
     GO111MODULE=on \
-    go build -a -o /go/bin/server ./proxy/
+    go mod tidy && go build -a -o /go/bin/server ./proxy/
 
 
 ###############################################################################
 # Stage 3: Copy binaries only to create the smallest final runtime image
 ###############################################################################
-FROM registry.access.redhat.com/ubi8/ubi-micro:8.7 as runtime
+FROM registry.access.redhat.com/ubi8/ubi-micro:8.8 as runtime
 
 ARG USER=2000
 

--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ fmt:
 .PHONY: test
 ## Run tests
 test:
-	go test -coverprofile cover.out `go list ./...`
+	go test -coverprofile cover.out `go list -buildvcs=false ./...`
 
 .DEFAULT_GOAL := help
 .PHONY: help

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kserve/rest-proxy
 
-go 1.18
+go 1.19
 
 require (
 	github.com/google/go-cmp v0.5.9

--- a/go.sum
+++ b/go.sum
@@ -13,6 +13,7 @@ github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0 h1:p104kn46Q8Wd
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
 github.com/golang/glog v1.0.0 h1:nfP3RFugxnNRyKgeWd4oI1nYvXpxrx8ck8ZrcizshdQ=
+github.com/golang/glog v1.0.0/go.mod h1:EWib/APOK0SL3dFbYqvxE3UYd8E6s1ouQ7iEp/0LWV4=
 github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
 github.com/golang/protobuf v1.5.3 h1:KhyjKVUg7Usr/dYsdSqoFveMYd5ko72D+zANwlG1mmg=
 github.com/golang/protobuf v1.5.3/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
@@ -127,6 +128,7 @@ gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 k8s.io/api v0.26.0 h1:IpPlZnxBpV1xl7TGk/X6lFtpgjgntCg8PJ+qrPHAC7I=
 k8s.io/apimachinery v0.27.0 h1:vEyy/PVMbPMCPutrssCVHCf0JNZ0Px+YqPi82K2ALlk=
 k8s.io/apimachinery v0.27.0/go.mod h1:5ikh59fK3AJ287GUvpUsryoMFtH9zj/ARfWCo3AyXTM=

--- a/scripts/fmt.sh
+++ b/scripts/fmt.sh
@@ -13,8 +13,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.#
 
+# Fix: 'fatal: detected dubious ownership in repository',
+# only do this if it is running into the develop image
+if [ "${PWD}" == "/opt/app" ]; then
+  git config --global --add safe.directory "*"
+fi
+
 pre-commit run --all-files
 RETURN_CODE=$?
+## cat this file for helping on identifying the root cause when some issue happens
+if [ -f /$USER/.cache/pre-commit/pre-commit.log ]; then
+  cat /$USER/.cache/pre-commit/pre-commit.log
+fi
 
 function echoError() {
   LIGHT_YELLOW='\033[1;33m'

--- a/scripts/fmt.sh
+++ b/scripts/fmt.sh
@@ -13,12 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.#
 
-# Fix: 'fatal: detected dubious ownership in repository',
-# only do this if it is running into the develop image
-if [ "${PWD}" == "/opt/app" ]; then
-  git config --global --add safe.directory "*"
-fi
-
 pre-commit run --all-files
 RETURN_CODE=$?
 ## cat this file for helping on identifying the root cause when some issue happens

--- a/scripts/fmt.sh
+++ b/scripts/fmt.sh
@@ -11,13 +11,13 @@
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
-# limitations under the License.#
+# limitations under the License.
 
 pre-commit run --all-files
 RETURN_CODE=$?
 ## cat this file for helping on identifying the root cause when some issue happens
-if [ -f /$USER/.cache/pre-commit/pre-commit.log ]; then
-  cat /$USER/.cache/pre-commit/pre-commit.log
+if [ -f .pre-commit.log ]; then
+  cat .pre-commit.log
 fi
 
 function echoError() {


### PR DESCRIPTION
**Fixed lint issues:**

```
Can't run linter goanalysis_metalinter: goanalysis_metalinter: buildir: package "netip" (isInitialPkg: false, needAnalyzeSource: true): in net/netip.AddrFromSlice: cannot convert Load <[]byte> t0 ([]byte) to [4]byte
```

**Warnings:**

```
WARN [runner] The linter 'structcheck' is deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter.  Replaced by unused.
WARN [runner] The linter 'deadcode' is deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter.  Replaced by unused.
WARN [runner] The linter 'varcheck' is deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter.  Replaced by unused.
```