### PR TITLE
fix: Remove InsecureSkipVerify

### DIFF
--- a/proxy/main.go
+++ b/proxy/main.go
@@ -85,9 +85,7 @@ func run() error {
 	var transportCreds credentials.TransportCredentials
 	if useTLS, ok := os.LookupEnv(restProxyTlsEnvVar); ok && useTLS == "true" {
 		logger.Info("Using TLS")
-		transportCreds = credentials.NewTLS(&tls.Config{
-			InsecureSkipVerify: true,
-		})
+		transportCreds = credentials.NewTLS(&tls.Config{})
 	} else {
 		logger.Info("Not using TLS")
 		transportCreds = insecure.NewCredentials()


### PR DESCRIPTION
Removes `InsecureSkipVerify: true`, which controls whether a client verifies the server's certificate chain/hostname. From [the docs](https://pkg.go.dev/crypto/tls#Config.InsecureSkipVerify), if `InsecureSkipVerify` is true, any certificate presented by the server and any host name in that certificate is accepted.

- Fixes https://github.com/kserve/rest-proxy/security/code-scanning/1