### PR TITLE
chore: Update Dockerfile to ubi9/ubi-micro:9.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -134,7 +134,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
 ###############################################################################
 # Stage 3: Copy binaries only to create the smallest final runtime image
 ###############################################################################
-FROM registry.access.redhat.com/ubi8/ubi-micro:latest as runtime
+FROM registry.access.redhat.com/ubi9/ubi-micro:9.4-6 as runtime
 
 ARG USER=2000
 


### PR DESCRIPTION
Re: https://github.com/kserve/rest-proxy/pull/42#pullrequestreview-2081513650

> We should use a specific version to ensure reproducible builds and/or to trace back in time when something last worked how/why what changed when ...

Alternatively, to stay on UBI 8, we could use the "latest" UBI 8 image `ubi8/ubi-micro:8.10-7`