### PR TITLE
Added new env var REST_PROXY_SKIP_VERIFY and set default to false

### DIFF
--- a/proxy/main.go
+++ b/proxy/main.go
@@ -34,12 +34,13 @@ import (
 )
 
 const (
-	restProxyPortEnvVar     = "REST_PROXY_LISTEN_PORT"
-	restProxyGrpcMaxMsgSize = "REST_PROXY_GRPC_MAX_MSG_SIZE_BYTES"
-	restProxyGrpcPortEnvVar = "REST_PROXY_GRPC_PORT"
-	restProxyTlsEnvVar      = "REST_PROXY_USE_TLS"
-	tlsCertEnvVar           = "MM_TLS_KEY_CERT_PATH"
-	tlsKeyEnvVar            = "MM_TLS_PRIVATE_KEY_PATH"
+	restProxyPortEnvVar       = "REST_PROXY_LISTEN_PORT"
+	restProxyGrpcMaxMsgSize   = "REST_PROXY_GRPC_MAX_MSG_SIZE_BYTES"
+	restProxyGrpcPortEnvVar   = "REST_PROXY_GRPC_PORT"
+	restProxyTlsEnvVar        = "REST_PROXY_USE_TLS"
+	restProxySkipVerifyEnvVar = "REST_PROXY_SKIP_VERIFY"
+	tlsCertEnvVar             = "MM_TLS_KEY_CERT_PATH"
+	tlsKeyEnvVar              = "MM_TLS_PRIVATE_KEY_PATH"
 )
 
 var (
@@ -85,8 +86,17 @@ func run() error {
 	var transportCreds credentials.TransportCredentials
 	if useTLS, ok := os.LookupEnv(restProxyTlsEnvVar); ok && useTLS == "true" {
 		logger.Info("Using TLS")
+		skipVerify, ok := os.LookupEnv(restProxySkipVerifyEnvVar)
+		if !ok {
+			skipVerify = "false"
+		}
+		parsedSkipVerify, err := strconv.ParseBool(skipVerify)
+		if err != nil {
+			logger.Error(err, "defaulting to false, unable to parse environment variable", "env", restProxySkipVerifyEnvVar)
+			parsedSkipVerify = false
+		}
 		transportCreds = credentials.NewTLS(&tls.Config{
-			InsecureSkipVerify: true,
+			InsecureSkipVerify: parsedSkipVerify,
 		})
 	} else {
 		logger.Info("Not using TLS")


### PR DESCRIPTION
Motivation
Allow users to set if they want to skip tls verification or not

Modifications
Adding logic to use an env variable to get user input. Defaults to false if not. 

Result
Users will be able to specify if they want to skip verification when using TLS