### PR TITLE
Upgrade Go lang, python and base images

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 repos:
   - repo: https://github.com/golangci/golangci-lint
-    rev: v1.51.1
+    rev: v1.60.3
     hooks:
       - id: golangci-lint
         log_file: .pre-commit.log

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kserve/rest-proxy
 
-go 1.21
+go 1.22.9
 
 require (
 	github.com/google/go-cmp v0.6.0

--- a/proxy/main.go
+++ b/proxy/main.go
@@ -90,7 +90,7 @@ func run() error {
 		skipVerifyBool := false
 		skipVerify, ok := os.LookupEnv(restProxySkipVerifyEnvVar)
 		if ok {
-			err := *new(error)
+			var err error
 			skipVerifyBool, err = strconv.ParseBool(skipVerify)
 			if err != nil {
 				logger.Error(err, "Failed to parse %s=%s to bool", restProxySkipVerifyEnvVar, skipVerify)


### PR DESCRIPTION
chore:	Update go lang to 1.22 since go-toolset image has bad grade.
	Update python from 3.8 to 3.11 and use alternatives to set the right python binary.
	Update the base images from UBI8 to UBI9.